### PR TITLE
Disable mandatory requirement for PKCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Enable PKCE in configuration `config/config.ex`:
 ```elixir
 config :my_app, ExOauth2Provider,
   # ...
-  # this will enable PKCE for *all* applications
+  # this will enable PKCE support
   use_pkce: true
 ```
 

--- a/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
+++ b/lib/ex_oauth2_provider/oauth2/authorization/strategy/code.ex
@@ -141,7 +141,7 @@ defmodule ExOauth2Provider.Authorization.Code do
 
   defp issue_grant({:error, %{error: _error} = params}, _config), do: {:error, params}
   defp issue_grant({:ok, %{resource_owner: resource_owner, client: application, request: request} = params}, config) do
-    filtered_request = if Config.use_pkce?(config) do
+    filtered_request = if Config.use_pkce?(config) and request["code_challenge"] do
       Map.merge(%{"code_challenge_method" => "plain"}, request)
       |> Map.take(["redirect_uri", "scope", "code_challenge", "code_challenge_method"])
       |> Map.update!("code_challenge", fn v -> String.replace(v, "=", "") end)
@@ -245,7 +245,7 @@ defmodule ExOauth2Provider.Authorization.Code do
       Error.add_error({:ok, params}, Error.invalid_request())
     end
   end
-  defp validate_pkce({:ok, params}, true), do: Error.add_error({:ok, params}, Error.invalid_request()) # missing code_challenge
+  defp validate_pkce({:ok, params}, true), do: {:ok, params} # missing code_challenge
 
   @sha256_byte_size 256/8
 

--- a/test/ex_oauth2_provider/oauth2/authorization/strategy/code_test.exs
+++ b/test/ex_oauth2_provider/oauth2/authorization/strategy/code_test.exs
@@ -157,7 +157,7 @@ defmodule ExOauth2Provider.Authorization.CodeTest do
   test "#authorize/3 generates grant without persisting code_challenge, code_challenge_method on disabled pkce", %{resource_owner: resource_owner} do
     request = Map.merge(@valid_request, %{"code_challenge" => "1234567890abcdefrety1234567890abcdefrety1234", "code_challenge_method" => "plain"})
 
-    assert {:native_redirect, %{code: code}} = Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider)
+    assert {:native_redirect, %{code: code}} = Authorization.authorize(resource_owner, request, otp_app: :ex_oauth2_provider, use_pkce: false)
     assert %{code_challenge: nil, code_challenge_method: nil} = Repo.get_by(OauthAccessGrant, token: code)
   end
 


### PR DESCRIPTION
`:use_pkce` changes its meaning slightly: when it's true, the PKCE support is enabled in general but not forcing any app to use it. Instead, when the authorization request comes with `code_challenge`, it means we store the challenge in `oauth_access_grants` and later use it when granting an access token.